### PR TITLE
Rename column name from "mean" to "copy_number"

### DIFF
--- a/micfunpreDefinitions/data/db/rrnDB_16S_cp.tsv
+++ b/micfunpreDefinitions/data/db/rrnDB_16S_cp.tsv
@@ -1,4 +1,4 @@
-name	mean
+name	copy_number
 Komagataeibacter europaeus	4.50
 Komagataeibacter xylinus	4.60
 Acholeplasma axanthum	2.00


### PR DESCRIPTION
This will match other copy number tables and allow pd.concat to work correctly